### PR TITLE
feat: Add 'complete' command to server.py

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -497,6 +497,33 @@ if __name__ == "__main__":
                             print(f"Index {index + 1} is out of bounds. Array length is 1-{len(experimenter.givenToPC)}.")
                 except (IndexError, ValueError):
                     print("Invalid command format. Use 'reset x' or 'reset x:y', where x and y are valid indices.")
+            elif user_input.startswith('complete '):
+                try:
+                    indices_str = user_input.split()[1]
+                    print(f"Marking indices as complete: {indices_str}")
+
+                    if ':' in indices_str:
+                        start_str, end_str = indices_str.split(':')
+                        start_1_based = int(start_str)
+                        end_1_based = int(end_str)
+
+                        if 1 <= start_1_based <= len(experimenter.data_array) and \
+                           1 <= end_1_based <= len(experimenter.data_array) and \
+                           start_1_based <= end_1_based:
+                            for i_1_based in range(start_1_based, end_1_based + 1):
+                                experimenter.complete(str(i_1_based), "Terminal")
+                                log(f"Marked index {i_1_based} as complete from terminal.")
+                        else:
+                            print(f"Invalid range. Ensure both indices are within 1-{len(experimenter.data_array)} and start <= end.")
+                    else:
+                        index_1_based = int(indices_str)
+                        if 1 <= index_1_based <= len(experimenter.data_array):
+                            experimenter.complete(str(index_1_based), "Terminal")
+                            log(f"Marked index {index_1_based} as complete from terminal.")
+                        else:
+                            print(f"Index {index_1_based} is out of bounds. Array length is 1-{len(experimenter.data_array)}.")
+                except (IndexError, ValueError):
+                    print("Invalid command format. Use 'complete x' or 'complete x:y', where x and y are valid indices.")
 
     except KeyboardInterrupt:
         print("\nKeyboardInterrupt detected. Shutting down the server...")


### PR DESCRIPTION
This commit introduces a new 'complete' command to the server's interactive terminal. The command allows you to manually mark experiments as complete, similar to how the 'reset' command works.

Key changes:
- Added an `elif` block in the main input loop in `server.py` to handle the `complete` command.
- The command supports two syntaxes:
    - `complete <index>`: Marks a single experiment as complete.
    - `complete <start_index>:<end_index>`: Marks a range of experiments as complete.
- Input parsing and error handling (e.g., for out-of-bounds indices or malformed commands) have been implemented, consistent with the 'reset' command.
- When an experiment is marked complete via this command, `experimenter.complete(ID, "Terminal")` is called.
- A log message is generated using the `log()` function (e.g., "Marked index X as complete from terminal") for each experiment successfully marked as complete.

This enhancement provides greater control over experiment state management directly from the server terminal.